### PR TITLE
Fix BuildCookRun skip switches being ignored

### DIFF
--- a/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/CookParameters.kt
+++ b/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/CookParameters.kt
@@ -11,7 +11,7 @@ object CookStageSwitchParameter : CheckboxParameter {
     override val advanced = false
 
     fun parseCookOptions(runnerParameters: Map<String, String>) =
-        runnerParameters[name]?.toBooleanStrictOrNull()?.let {
+        runnerParameters[name]?.toBooleanStrictOrNull()?.takeIf { it }?.let {
             CookOptions.from(runnerParameters)
         }
 }

--- a/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/PackagingParameters.kt
+++ b/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/PackagingParameters.kt
@@ -19,7 +19,7 @@ object ArchiveSwitchParameter : CheckboxParameter {
     override val advanced = false
 
     fun parseArchiveOptions(runnerParameters: Map<String, String>) =
-        runnerParameters[name]?.toBooleanStrictOrNull()?.let {
+        runnerParameters[name]?.toBooleanStrictOrNull()?.takeIf { it }?.let {
             ArchiveOptions.from(runnerParameters)
         }
 }

--- a/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/StageParameters.kt
+++ b/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/StageParameters.kt
@@ -11,7 +11,7 @@ object StageStageSwitchParameter : CheckboxParameter {
     override val advanced = false
 
     fun parseStageOptions(runnerParameters: Map<String, String>) =
-        runnerParameters[name]?.toBooleanStrictOrNull()?.let {
+        runnerParameters[name]?.toBooleanStrictOrNull()?.takeIf { it }?.let {
             StageOptions.from(runnerParameters)
         }
 }

--- a/common/src/test/kotlin/BuildCookRunExecCommandTests.kt
+++ b/common/src/test/kotlin/BuildCookRunExecCommandTests.kt
@@ -8,6 +8,10 @@ import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildConf
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildConfigurationParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildCookRunCommand
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildCookRunProjectPathParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ArchiveSwitchParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookStageSwitchParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.PackageStageSwitchParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.StageStageSwitchParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnrealTargetConfigurationsParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnrealTargetPlatformsParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.parameters.AdditionalArgumentsParameter
@@ -163,6 +167,37 @@ class BuildCookRunExecCommandTests {
                         "-build",
                         "-serverconfig=Shipping",
                         "-servertargetplatform=Linux+LinuxArm64",
+                        "-skipcook",
+                        "-skipstage",
+                    ),
+            ),
+            HappyPathTestCase(
+                runnerParameters =
+                    mapOf(
+                        BuildCookRunProjectPathParameter.name to "some-path",
+                        BuildConfigurationParameter.name to "StandaloneGame",
+                        UnrealTargetConfigurationsParameter.Standalone.name to "Shipping",
+                        UnrealTargetPlatformsParameter.Standalone.name to "Win64",
+                        CookStageSwitchParameter.name to false.toString(),
+                        StageStageSwitchParameter.name to false.toString(),
+                        ArchiveSwitchParameter.name to false.toString(),
+                        PackageStageSwitchParameter.name to false.toString(),
+                    ),
+                parsedCommand =
+                    BuildCookRunCommand(
+                        UnrealProjectPath("some-path"),
+                        BuildConfiguration.Standalone(
+                            nonEmptyListOf(UnrealTargetConfiguration.Shipping),
+                            nonEmptyListOf(UnrealTargetPlatform.Win64),
+                        ),
+                    ),
+                expectedArguments =
+                    listOf(
+                        "BuildCookRun",
+                        "-project=${context.workingDirectory}/some-path",
+                        "-build",
+                        "-configuration=Shipping",
+                        "-targetplatform=Win64",
                         "-skipcook",
                         "-skipstage",
                     ),


### PR DESCRIPTION
## What
- honor the actual boolean value for `build-cook-run-cook`, `build-cook-run-stage`, and `build-cook-run-archive`
- only create cook/stage/archive options when the corresponding switch is `true`
- add regression coverage in `BuildCookRunExecCommandTests` for explicit `false` values
## Why
`toBooleanStrictOrNull()` was used only as a null-check. For `false`, parsing returned non-null and options were still created, which always emitted `-cook`, `-stage`, and `-archive`.
## Validation
- `./gradlew :common:test --tests BuildCookRunExecCommandTests` (run as `gradlew.bat` on Windows)
Fixes #22
Fixes #14