### PR TITLE
Avoid false build failures for suppressed automation test logs

### DIFF
--- a/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/automation/tests/RunAutomationTestsWorkflowCreator.kt
+++ b/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/automation/tests/RunAutomationTestsWorkflowCreator.kt
@@ -55,7 +55,10 @@ class RunAutomationTestsWorkflowCreator(
                 toolRegistry.editor(context.runnerParameters).executablePath,
                 arguments,
             ),
-            processListenerFactory.create(AutomationTestLogEventHandler(context)),
+            processListenerFactory.create(
+                AutomationTestLogEventHandler(context),
+                reportErrorsAsBuildProblems = false,
+            ),
         )
     }
 }

--- a/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/build/log/UnrealEngineProcessListener.kt
+++ b/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/build/log/UnrealEngineProcessListener.kt
@@ -12,11 +12,15 @@ class UnrealEngineProcessListenerFactory(
     private val logEventParser: UnrealLogEventParser,
 ) {
     context(context: UnrealBuildContext)
-    fun create(vararg handlers: LogEventHandler) =
+    fun create(
+        vararg handlers: LogEventHandler,
+        reportErrorsAsBuildProblems: Boolean = true,
+    ) =
         UnrealEngineProcessListener(
             context.build.buildLogger,
             logEventParser,
             handlers.asList(),
+            reportErrorsAsBuildProblems,
         )
 }
 
@@ -24,6 +28,7 @@ class UnrealEngineProcessListener(
     private val buildLogger: BuildProgressLogger,
     private val logEventParser: UnrealLogEventParser,
     private val handlers: Collection<LogEventHandler>,
+    private val reportErrorsAsBuildProblems: Boolean = true,
 ) : ProcessListenerAdapter() {
     companion object {
         private val agentLogger = UnrealPluginLoggers.get<BuildCookRunWorkflowCreator>()
@@ -50,7 +55,12 @@ class UnrealEngineProcessListener(
         when (event.level) {
             LogLevel.Error, LogLevel.Critical -> {
                 buildStdOutLogger.error(event.message)
-                buildLogger.logBuildProblem(event.asBuildProblem())
+
+                if (reportErrorsAsBuildProblems) {
+                    buildLogger.logBuildProblem(event.asBuildProblem())
+                } else {
+                    buildLogger.warning(event.message)
+                }
             }
             LogLevel.Warning -> {
                 buildStdOutLogger.warn(event.message)

--- a/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/buildgraph/DistributedExecutor.kt
+++ b/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/buildgraph/DistributedExecutor.kt
@@ -80,7 +80,10 @@ class DistributedExecutor(
                     "-SharedStorageDir=$sharedDir",
                     "-WriteToSharedStorage",
                 ),
-            processListenerFactory.create(AutomationTestLogEventHandler(context)),
+            processListenerFactory.create(
+                AutomationTestLogEventHandler(context),
+                reportErrorsAsBuildProblems = false,
+            ),
         )
     }
 

--- a/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/buildgraph/SingleMachineExecutor.kt
+++ b/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/buildgraph/SingleMachineExecutor.kt
@@ -27,7 +27,10 @@ class SingleMachineExecutor(
                     toolRegistry.automationTool(context.runnerParameters).executablePath,
                     command.toArguments(),
                 ),
-                processListenerFactory.create(AutomationTestLogEventHandler(context)),
+                processListenerFactory.create(
+                    AutomationTestLogEventHandler(context),
+                    reportErrorsAsBuildProblems = false,
+                ),
             ),
         )
 }

--- a/agent/src/test/kotlin/UnrealEngineProcessListenerTests.kt
+++ b/agent/src/test/kotlin/UnrealEngineProcessListenerTests.kt
@@ -86,10 +86,41 @@ class UnrealEngineProcessListenerTests {
         }
     }
 
-    private fun createListener(vararg handlers: LogEventHandler) =
+    @Test
+    fun `reports errors as build problems by default`() {
+        // arrange
+        every { logEventParser.parse(any()) } returns logEvent.copy(level = LogLevel.Error)
+        val listener = createListener()
+
+        // act
+        listener.onStandardOutput(logEvent.message)
+
+        // assert
+        verify { buildLogger.logBuildProblem(any()) }
+    }
+
+    @Test
+    fun `can skip build problems for error logs`() {
+        // arrange
+        every { logEventParser.parse(any()) } returns logEvent.copy(level = LogLevel.Error)
+        val listener = createListener(reportErrorsAsBuildProblems = false)
+
+        // act
+        listener.onStandardOutput(logEvent.message)
+
+        // assert
+        verify(exactly = 0) { buildLogger.logBuildProblem(any()) }
+        verify { buildLogger.warning(logEvent.message) }
+    }
+
+    private fun createListener(
+        vararg handlers: LogEventHandler,
+        reportErrorsAsBuildProblems: Boolean = true,
+    ) =
         UnrealEngineProcessListener(
             buildLogger,
             logEventParser,
             handlers.asList(),
+            reportErrorsAsBuildProblems,
         )
 }


### PR DESCRIPTION
## What
- add a `reportErrorsAsBuildProblems` switch to `UnrealEngineProcessListener`
- keep the current default behavior (`true`) for regular Unreal commands
- disable build-problem reporting for automation-test workflows (`RunAutomationTests` and BuildGraph automation handlers)
- when disabled, error-level logs are still visible in the build log as warnings
- add regression tests in `UnrealEngineProcessListenerTests`
## Why
Automation tests can intentionally emit error logs (for example negative tests with `FAutomationTestBase::bSuppressLogs`) while still returning a successful exit code. Treating every error log as a TeamCity build problem causes false build failures.
## Validation
- `./gradlew :agent:test --tests UnrealEngineProcessListenerTests --tests RunAutomationTestsWorkflowCreatorTests --tests DistributedExecutorTests --tests SingleMachineExecutorTests` (run as `gradlew.bat` on Windows)
Fixes #15