### PR TITLE
Propagate clean checkout to distributed BuildGraph virtual builds

### DIFF
--- a/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/buildgraph/BuildGraphVirtualBuildCreator.kt
+++ b/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/buildgraph/BuildGraphVirtualBuildCreator.kt
@@ -6,6 +6,7 @@ import com.jetbrains.teamcity.plugins.unrealengine.server.extensions.generateIdF
 import com.jetbrains.teamcity.plugins.unrealengine.server.extensions.markAsGeneratedBy
 import com.jetbrains.teamcity.plugins.unrealengine.server.extensions.setRevisionsFrom
 import jetbrains.buildServer.serverSide.BuildPromotion
+import jetbrains.buildServer.serverSide.BuildAttributes
 import jetbrains.buildServer.serverSide.BuildPromotionEx
 import jetbrains.buildServer.serverSide.BuildTypeSettings
 import jetbrains.buildServer.serverSide.SimpleParameter
@@ -51,8 +52,14 @@ class BuildGraphVirtualBuildCreator(
 
         build.setRevisionsFrom(context.originalBuild)
         build.markAsGeneratedBy(context.originalBuild)
+        build.propagateCleanSourcesFrom(context.originalBuild)
 
         return build
+    }
+
+    private fun BuildPromotionEx.propagateCleanSourcesFrom(source: BuildPromotionEx) {
+        val cleanSources = source.getAttribute(BuildAttributes.CLEAN_SOURCES)?.toString() ?: return
+        setAttribute(BuildAttributes.CLEAN_SOURCES, cleanSources)
     }
 
     private fun String.toExternalId() = restrictedIdCharactersRegex.replace(this, "_")

--- a/server/src/test/kotlin/buildgraph/BuildGraphVirtualBuildCreatorTests.kt
+++ b/server/src/test/kotlin/buildgraph/BuildGraphVirtualBuildCreatorTests.kt
@@ -6,7 +6,9 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import jetbrains.buildServer.BuildTypeDescriptor.CheckoutType
+import jetbrains.buildServer.serverSide.BuildAttributes
 import jetbrains.buildServer.serverSide.BuildPromotionEx
 import jetbrains.buildServer.serverSide.SBuildType
 import jetbrains.buildServer.virtualConfiguration.generator.VirtualBuildTypeSettings
@@ -23,6 +25,7 @@ import kotlin.test.assertTrue
 
 class BuildGraphVirtualBuildCreatorTests {
     private val originalBuild = mockk<BuildPromotionEx>(relaxed = true)
+    private val generatedBuild = mockk<BuildPromotionEx>(relaxed = true)
     private val buildGeneratorFactory = mockk<VirtualPromotionGeneratorFactory>()
     private val buildTypeConfigurationSlot = slot<BiFunction<SBuildType, String, Boolean>>()
     private val virtualBuildTypeSettingsSlot = slot<VirtualBuildTypeSettings>()
@@ -43,7 +46,7 @@ class BuildGraphVirtualBuildCreatorTests {
                             capture(virtualBuildTypeSettingsSlot),
                             capture(buildTypeConfigurationSlot),
                         )
-                    } returns mockk<BuildPromotionEx>(relaxed = true)
+                    } returns generatedBuild
                 }
         }
     }
@@ -107,6 +110,21 @@ class BuildGraphVirtualBuildCreatorTests {
             originalBuildParameters.all {
                 virtualBuildTypeParameters[it.key]?.value == it.value
             }
+        }
+    }
+
+    @Test
+    fun `propagates clean sources attribute from the original build`() {
+        // arrange
+        val buildCreator = BuildGraphVirtualBuildCreator(buildGeneratorFactory)
+        every { originalBuild.getAttribute(BuildAttributes.CLEAN_SOURCES) } returns true.toString()
+
+        // act
+        with(buildCreator.inContextOf(originalBuild)) { buildCreator.create("foo") {} }
+
+        // assert
+        verify {
+            generatedBuild.setAttribute(BuildAttributes.CLEAN_SOURCES, true.toString())
         }
     }
 


### PR DESCRIPTION
## What
- propagate `BuildAttributes.CLEAN_SOURCES` from the original build promotion to every generated BuildGraph virtual build
- keep existing checkout directory/type propagation unchanged
- add regression coverage in `BuildGraphVirtualBuildCreatorTests`
## Why
With distributed BuildGraph, generated virtual builds execute graph nodes on multiple agents. If the original build requests a clean checkout (`delete all files in the checkout directory before the build`), that intent must be copied to generated promotions too; otherwise only setup/parent behavior is cleaned and node builds may reuse stale files.
## Validation
- `./gradlew :server:test --tests buildgraph.BuildGraphVirtualBuildCreatorTests -x :server:buildFront` (run as `gradlew.bat` on Windows)
Fixes #20