### PR TITLE
Sync distributed BuildGraph addBuildTag results to parent build

### DIFF
--- a/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/ServerExtensionPointsRegistration.kt
+++ b/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/ServerExtensionPointsRegistration.kt
@@ -2,6 +2,7 @@ package com.jetbrains.teamcity.plugins.unrealengine.server
 
 import com.jetbrains.teamcity.plugins.unrealengine.server.build.agent.AgentBuildEventReceiver
 import com.jetbrains.teamcity.plugins.unrealengine.server.build.state.SkippedBuildMonitor
+import com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphParentTagSyncListener
 import com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphSetupBuildListener
 import jetbrains.buildServer.serverSide.SBuildServer
 import jetbrains.buildServer.serverSide.ServerExtensionHolder
@@ -10,12 +11,14 @@ class ServerExtensionPointsRegistration(
     private val server: SBuildServer,
     private val extensions: ServerExtensionHolder,
     private val buildGraphSetupBuildListener: BuildGraphSetupBuildListener,
+    private val buildGraphParentTagSyncListener: BuildGraphParentTagSyncListener,
     private val agentBuildEventReceiver: AgentBuildEventReceiver,
     private val buildEventMonitor: SkippedBuildMonitor,
     private val backgroundJobsScope: BackgroundJobsScope,
 ) {
     fun register() {
         server.addListener(buildGraphSetupBuildListener)
+        server.addListener(buildGraphParentTagSyncListener)
         server.addListener(backgroundJobsScope)
         server.addListener(buildEventMonitor)
         extensions.registerExtension(

--- a/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/buildgraph/BuildGraphParentTagSyncListener.kt
+++ b/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/buildgraph/BuildGraphParentTagSyncListener.kt
@@ -1,0 +1,43 @@
+package com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph
+
+import com.jetbrains.teamcity.plugins.unrealengine.common.UnrealPluginLoggers
+import com.jetbrains.teamcity.plugins.unrealengine.server.extensions.asBuildPromotionEx
+import com.jetbrains.teamcity.plugins.unrealengine.server.extensions.getGeneratedById
+import jetbrains.buildServer.serverSide.BuildPromotionManager
+import jetbrains.buildServer.serverSide.BuildServerAdapter
+import jetbrains.buildServer.serverSide.SBuild
+import jetbrains.buildServer.serverSide.SRunningBuild
+
+class BuildGraphParentTagSyncListener(
+    private val promotionManager: BuildPromotionManager,
+) : BuildServerAdapter() {
+    companion object {
+        private val logger = UnrealPluginLoggers.get<BuildGraphParentTagSyncListener>()
+    }
+
+    override fun beforeBuildFinish(runningBuild: SRunningBuild) {
+        val parentBuild = findParentBuild(runningBuild) ?: return
+        val childTags = runningBuild.tags
+        if (childTags.isEmpty()) {
+            return
+        }
+
+        val mergedTags = (parentBuild.tags + childTags).distinct()
+        if (mergedTags == parentBuild.tags) {
+            return
+        }
+
+        logger.debug(
+            "Syncing tags from generated BuildGraph build ${runningBuild.buildId} to parent build ${parentBuild.buildId}: $childTags",
+        )
+        parentBuild.setTags(mergedTags)
+    }
+
+    private fun findParentBuild(build: SBuild): SBuild? {
+        val generatedById = build.buildPromotion.asBuildPromotionEx().getGeneratedById() ?: return null
+        val parentPromotion = promotionManager.findPromotionById(generatedById) ?: return null
+
+        return parentPromotion.associatedBuild
+    }
+}
+

--- a/server/src/main/resources/META-INF/build-server-plugin-unreal-engine.xml
+++ b/server/src/main/resources/META-INF/build-server-plugin-unreal-engine.xml
@@ -28,6 +28,7 @@
     <bean class="com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphParser"/>
     <bean class="com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphDistributedBuildCreator"/>
     <bean class="com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphSetupBuildListener"/>
+    <bean class="com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphParentTagSyncListener"/>
     <bean class="com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphSetupBuildValidator"/>
     <bean class="com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphDistributedSetupOrchestrator"/>
     <bean class="com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphDependencyConnector"/>

--- a/server/src/test/kotlin/buildgraph/BuildGraphParentTagSyncListenerTests.kt
+++ b/server/src/test/kotlin/buildgraph/BuildGraphParentTagSyncListenerTests.kt
@@ -1,0 +1,85 @@
+package buildgraph
+
+import com.jetbrains.teamcity.plugins.unrealengine.server.buildgraph.BuildGraphParentTagSyncListener
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jetbrains.buildServer.serverSide.BuildPromotionEx
+import jetbrains.buildServer.serverSide.BuildPromotionManager
+import jetbrains.buildServer.serverSide.SBuild
+import jetbrains.buildServer.serverSide.SRunningBuild
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+
+class BuildGraphParentTagSyncListenerTests {
+    private val promotionManager = mockk<BuildPromotionManager>()
+    private val childBuild = mockk<SRunningBuild>()
+    private val childPromotion = mockk<BuildPromotionEx>()
+    private val parentPromotion = mockk<BuildPromotionEx>()
+    private val parentBuild = mockk<SBuild>(relaxed = true)
+
+    @BeforeEach
+    fun init() {
+        clearAllMocks()
+
+        every { childBuild.buildPromotion } returns childPromotion
+        every { childBuild.buildId } returns 1001L
+
+        every {
+            childPromotion.getAttribute("teamcity.build.unreal-engine.build-graph.generated-by")
+        } returns null
+
+        every { promotionManager.findPromotionById(any()) } returns parentPromotion
+        every { parentPromotion.associatedBuild } returns parentBuild
+
+        every { parentBuild.buildId } returns 1000L
+        every { parentBuild.tags } returns listOf("ParentTag")
+        every { parentBuild.setTags(any()) } returns Unit
+    }
+
+    @Test
+    fun `does nothing for non-generated builds`() {
+        // arrange
+        every { childBuild.tags } returns listOf("ChildTag")
+
+        // act
+        BuildGraphParentTagSyncListener(promotionManager).beforeBuildFinish(childBuild)
+
+        // assert
+        verify(exactly = 0) { promotionManager.findPromotionById(any()) }
+        verify(exactly = 0) { parentBuild.setTags(any()) }
+    }
+
+    @Test
+    fun `syncs tags to parent build for generated builds`() {
+        // arrange
+        every {
+            childPromotion.getAttribute("teamcity.build.unreal-engine.build-graph.generated-by")
+        } returns "1000"
+        every { childBuild.tags } returns listOf("ChildTag", "ParentTag")
+
+        // act
+        BuildGraphParentTagSyncListener(promotionManager).beforeBuildFinish(childBuild)
+
+        // assert
+        verify { promotionManager.findPromotionById(1000L) }
+        verify { parentBuild.setTags(listOf("ParentTag", "ChildTag")) }
+    }
+
+    @Test
+    fun `does nothing when child has no tags`() {
+        // arrange
+        every {
+            childPromotion.getAttribute("teamcity.build.unreal-engine.build-graph.generated-by")
+        } returns "1000"
+        every { childBuild.tags } returns emptyList()
+
+        // act
+        BuildGraphParentTagSyncListener(promotionManager).beforeBuildFinish(childBuild)
+
+        // assert
+        verify(exactly = 0) { parentBuild.setTags(any()) }
+    }
+}
+


### PR DESCRIPTION
## What
- add `BuildGraphParentTagSyncListener` to mirror tags from generated distributed BuildGraph child builds to the original parent build
- resolve parent build via the existing `generated-by` build-promotion marker
- merge tags with deduplication (`parent + child`), and only write when there is an actual change
- register the listener in server extension points and Spring config
- add focused tests in `BuildGraphParentTagSyncListenerTests`
## Why
In distributed BuildGraph runs, `##teamcity[addBuildTag ...]` applies to the generated virtual child build. This listener keeps parent build tags in sync so the user-visible/original build receives the tags as expected.
## Validation
- `./gradlew :server:test --tests buildgraph.BuildGraphParentTagSyncListenerTests --tests buildgraph.BuildGraphVirtualBuildCreatorTests -x :server:buildFront` (run as `gradlew.bat` on Windows)
Fixes #21