### PR TITLE
Publish commandlet warning/error statistics as TeamCity build metrics

### DIFF
--- a/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/commandlets/CommandletWorkflowCreator.kt
+++ b/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/commandlets/CommandletWorkflowCreator.kt
@@ -11,6 +11,7 @@ import com.jetbrains.teamcity.plugins.unrealengine.agent.UnrealToolRegistry
 import com.jetbrains.teamcity.plugins.unrealengine.agent.Workflow
 import com.jetbrains.teamcity.plugins.unrealengine.agent.WorkflowCreator
 import com.jetbrains.teamcity.plugins.unrealengine.agent.build.log.UnrealEngineProcessListenerFactory
+import com.jetbrains.teamcity.plugins.unrealengine.agent.reporting.CommandletLogEventHandler
 import com.jetbrains.teamcity.plugins.unrealengine.common.GenericError
 import com.jetbrains.teamcity.plugins.unrealengine.common.UnrealPluginLoggers
 import com.jetbrains.teamcity.plugins.unrealengine.common.commandlets.RunCommandletCommand
@@ -54,7 +55,7 @@ class CommandletWorkflowCreator(
                 toolRegistry.editor(context.runnerParameters).executablePath,
                 arguments,
             ),
-            processListenerFactory.create(),
+            processListenerFactory.create(CommandletLogEventHandler(context)),
         )
     }
 }

--- a/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/reporting/CommandletLogEventHandler.kt
+++ b/agent/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/agent/reporting/CommandletLogEventHandler.kt
@@ -1,0 +1,47 @@
+package com.jetbrains.teamcity.plugins.unrealengine.agent.reporting
+
+import com.jetbrains.teamcity.plugins.unrealengine.agent.UnrealBuildContext
+import com.jetbrains.teamcity.plugins.unrealengine.agent.build.log.LogEventHandler
+import com.jetbrains.teamcity.plugins.unrealengine.agent.build.log.LogLevel
+import com.jetbrains.teamcity.plugins.unrealengine.agent.build.log.UnrealLogEvent
+
+class CommandletLogEventHandler(
+    private val context: UnrealBuildContext,
+) : LogEventHandler {
+    private var warningCount = 0
+    private var errorCount = 0
+
+    override fun tryHandleEvent(event: UnrealLogEvent): Boolean {
+        when (event.level) {
+            LogLevel.Warning -> {
+                warningCount++
+                publishStatistic(WARNING_COUNT_KEY, warningCount)
+            }
+
+            LogLevel.Error, LogLevel.Critical -> {
+                errorCount++
+                publishStatistic(ERROR_COUNT_KEY, errorCount)
+            }
+
+            else -> Unit
+        }
+
+        // Let the normal listener pipeline continue to keep existing logging behavior.
+        return false
+    }
+
+    private fun publishStatistic(
+        key: String,
+        value: Int,
+    ) {
+        context.build.buildLogger.message(
+            "##teamcity[buildStatisticValue key='$key' value='$value']",
+        )
+    }
+
+    companion object {
+        const val WARNING_COUNT_KEY = "unreal.commandlet.warnings"
+        const val ERROR_COUNT_KEY = "unreal.commandlet.errors"
+    }
+}
+

--- a/agent/src/test/kotlin/CommandletLogEventHandlerTests.kt
+++ b/agent/src/test/kotlin/CommandletLogEventHandlerTests.kt
@@ -1,0 +1,84 @@
+import com.jetbrains.teamcity.plugins.unrealengine.agent.build.log.LogLevel
+import com.jetbrains.teamcity.plugins.unrealengine.agent.build.log.UnrealLogEvent
+import com.jetbrains.teamcity.plugins.unrealengine.agent.reporting.CommandletLogEventHandler
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import jetbrains.buildServer.agent.BuildProgressLogger
+import org.junit.jupiter.api.BeforeEach
+import java.time.Instant
+import kotlin.test.Test
+
+class CommandletLogEventHandlerTests {
+    private val buildLoggerMock = mockk<BuildProgressLogger>(relaxed = true)
+    private val buildContext = createTestUnrealBuildContext()
+    private val handler = CommandletLogEventHandler(buildContext)
+
+    @BeforeEach
+    fun init() {
+        clearAllMocks()
+        every { buildContext.build.buildLogger } returns buildLoggerMock
+    }
+
+    @Test
+    fun `publishes incremental warning statistics`() {
+        // arrange
+        val warningEvent = createEvent(LogLevel.Warning)
+
+        // act
+        val firstHandled = handler.tryHandleEvent(warningEvent)
+        val secondHandled = handler.tryHandleEvent(warningEvent)
+
+        // assert
+        firstHandled shouldBe false
+        secondHandled shouldBe false
+        verifyOrder {
+            buildLoggerMock.message("##teamcity[buildStatisticValue key='unreal.commandlet.warnings' value='1']")
+            buildLoggerMock.message("##teamcity[buildStatisticValue key='unreal.commandlet.warnings' value='2']")
+        }
+    }
+
+    @Test
+    fun `publishes incremental error statistics for error and critical levels`() {
+        // arrange
+        val errorEvent = createEvent(LogLevel.Error)
+        val criticalEvent = createEvent(LogLevel.Critical)
+
+        // act
+        val firstHandled = handler.tryHandleEvent(errorEvent)
+        val secondHandled = handler.tryHandleEvent(criticalEvent)
+
+        // assert
+        firstHandled shouldBe false
+        secondHandled shouldBe false
+        verifyOrder {
+            buildLoggerMock.message("##teamcity[buildStatisticValue key='unreal.commandlet.errors' value='1']")
+            buildLoggerMock.message("##teamcity[buildStatisticValue key='unreal.commandlet.errors' value='2']")
+        }
+    }
+
+    @Test
+    fun `ignores non-warning and non-error events`() {
+        // arrange
+        val lines = listOf(createEvent(LogLevel.Information), createEvent(LogLevel.Debug), createEvent(LogLevel.Trace))
+
+        // act
+        val handledCount = lines.count { handler.tryHandleEvent(it) }
+
+        // assert
+        handledCount shouldBe 0
+        confirmVerified(buildLoggerMock)
+    }
+
+    private fun createEvent(level: LogLevel) =
+        UnrealLogEvent(
+            time = Instant.now(),
+            level = level,
+            message = "test-message",
+            channel = null,
+        )
+}
+

--- a/agent/src/test/kotlin/CommandletWorkflowCreatorTests.kt
+++ b/agent/src/test/kotlin/CommandletWorkflowCreatorTests.kt
@@ -1,0 +1,70 @@
+import arrow.core.raise.Raise
+import arrow.core.raise.either
+import com.jetbrains.teamcity.plugins.framework.common.Environment
+import com.jetbrains.teamcity.plugins.framework.common.OSType
+import com.jetbrains.teamcity.plugins.unrealengine.agent.UnrealBuildContext
+import com.jetbrains.teamcity.plugins.unrealengine.agent.UnrealTool
+import com.jetbrains.teamcity.plugins.unrealengine.agent.UnrealToolRegistry
+import com.jetbrains.teamcity.plugins.unrealengine.agent.UnrealToolType
+import com.jetbrains.teamcity.plugins.unrealengine.agent.commandlets.CommandletWorkflowCreator
+import com.jetbrains.teamcity.plugins.unrealengine.agent.build.log.UnrealEngineProcessListenerFactory
+import com.jetbrains.teamcity.plugins.unrealengine.common.GenericError
+import com.jetbrains.teamcity.plugins.unrealengine.common.commandlets.CommandletNameParameter
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+
+class CommandletWorkflowCreatorTests {
+    private val environment = mockk<Environment>()
+    private val processListenerFactory = mockk<UnrealEngineProcessListenerFactory>(relaxed = true)
+    private val toolRegistry = mockk<UnrealToolRegistry>()
+    private val context = createTestUnrealBuildContext()
+
+    @BeforeEach
+    fun init() {
+        clearAllMocks()
+        setupTestUnrealBuildContext(context)
+
+        every { context.runnerParameters } returns
+            mapOf(
+                CommandletNameParameter.name to "ResavePackages",
+            )
+
+        with(toolRegistry) {
+            coEvery {
+                with(any<UnrealBuildContext>()) {
+                    with(any<Raise<GenericError>>()) {
+                        editor(any())
+                    }
+                }
+            } returns UnrealTool("/foo/bar", UnrealToolType.Editor)
+        }
+
+        with(environment) {
+            every { osType } returns OSType.MacOs
+        }
+    }
+
+    @Test
+    fun `contains a single command in the workflow`() =
+        runTest {
+            // arrange
+            val creator = CommandletWorkflowCreator(toolRegistry, environment, processListenerFactory)
+
+            // act
+            val workflow = with(context) { either { creator.create() } }.getOrNull()
+
+            // assert
+            workflow shouldNotBe null
+            workflow!!.commands shouldHaveSize 1
+        }
+
+}
+
+


### PR DESCRIPTION
## What
- add `CommandletLogEventHandler` that tracks commandlet warnings and errors from structured log levels
- publish TeamCity build statistics via service messages:
  - `unreal.commandlet.warnings`
  - `unreal.commandlet.errors`
- wire this handler into `CommandletWorkflowCreator` so commandlet runs emit live warning/error counters
- add focused tests for handler behavior and commandlet workflow creation
## Why
Unreal Editor commandlets can emit summary-like warning/error information in logs. Exposing these counts as build statistics makes them visible and chartable in TeamCity without engine modifications.
## Validation
- `./gradlew :agent:test --tests CommandletLogEventHandlerTests --tests CommandletWorkflowCreatorTests` (Windows: `gradlew.bat`)
- `./gradlew :agent:test` (Windows: `gradlew.bat`)
Fixes #13