### PR TITLE
Add native BuildCookRun cooker and packaging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added native BuildCookRun support for advanced cooker and packaging options such as `AdditionalCookerOptions`, chunk generation, iterative cooking, cook-all/cook-maps-only controls, partial GC, FastCook, ignore-cook-errors, editor-content exclusion, IoStore, manifests, distribution mode, NoXGE, NoDebugInfo, SkipEncryption, and related flags.
+
 ### Changed
 
 ### Fixed

--- a/USAGE.md
+++ b/USAGE.md
@@ -76,6 +76,13 @@ The plugin includes the following predefined commands:
 * `BuildCookRun`
 * `BuildGraph` (distributed mode is a bit trickier, though - check the corresponding section below)
 
+`BuildCookRun` supports a native set of cook, staging, packaging, and archive options.
+For more specialized workflows, you can also configure advanced options such as
+`generateChunks`, `iterativeCooking`, `cookAll`, `cookMapsOnly`, `cookPartialGC`,
+`fastCook`, `ignoreCookErrors`, `skipCookingEditorContent`, `excludeEditorContent`,
+`iostore`, `manifests`, `distribution`, `noXGE`, `noDebugInfo`, `skipEncryption`, and
+`additionalCookerOptions` without falling back to raw `additionalArguments` strings.
+
 #### Custom Automation Commands
 
 You can also execute any custom automation command using the runner’s `RunAutomationCommand` option.
@@ -99,6 +106,44 @@ unrealEngine {
     }
     additionalArguments = "-buildmachine -unattended -noP4"
     ...
+}
+```
+
+#### BuildCookRun example with native cooker options
+
+```kotlin
+unrealEngine {
+    engineDetectionMode = manual {
+        rootDir = "%teamcity.build.checkoutDir%/Engine"
+    }
+
+    command = buildCookRun {
+        project = "%build.projectPath%"
+        buildConfiguration = standaloneGame {
+            configurations = "%build.config%"
+            platforms = "%build.platforms%"
+        }
+        cook = cookConfiguration {
+            generateChunks = true
+            iterativeCooking = true
+            cookAll = true
+            cookMapsOnly = true
+            cookPartialGC = true
+            fastCook = true
+            ignoreCookErrors = false
+            skipCookingEditorContent = true
+            excludeEditorContent = true
+            additionalCookerOptions = "-cookincremental -cookprocesscount=1"
+        }
+        iostore = true
+        manifests = true
+        installedBuild = true
+        noXGE = true
+        noDebugInfo = true
+        skipEncryption = false
+        distribution = false
+        logWindow = true
+    }
 }
 ```
 

--- a/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/BuildCookRunAdditionalOptions.kt
+++ b/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/BuildCookRunAdditionalOptions.kt
@@ -1,0 +1,244 @@
+package com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun
+
+import com.jetbrains.teamcity.plugins.unrealengine.common.parameters.CheckboxParameter
+import jetbrains.buildServer.util.StringUtil
+
+object InstalledBuildParameter : CheckboxParameter {
+    override val name = "build-cook-run-installed"
+    override val displayName = "Installed build"
+    override val defaultValue = ""
+    override val description = "Use an installed engine build."
+    override val advanced = true
+}
+
+object CompileParameter : CheckboxParameter {
+    override val name = "build-cook-run-compile"
+    override val displayName = "Compile"
+    override val defaultValue = ""
+    override val description = "Compile the targets before running BuildCookRun."
+    override val advanced = true
+}
+
+object UseIoStoreParameter : CheckboxParameter {
+    override val name = "build-cook-run-iostore"
+    override val displayName = "IoStore"
+    override val defaultValue = ""
+    override val description = "Store assets in IoStore containers."
+    override val advanced = true
+}
+
+object NoCompileUATParameter : CheckboxParameter {
+    override val name = "build-cook-run-no-compile-uat"
+    override val displayName = "NoCompileUAT"
+    override val defaultValue = ""
+    override val description = "Skip compiling Unreal Automation Tool."
+    override val advanced = true
+}
+
+object ManifestsParameter : CheckboxParameter {
+    override val name = "build-cook-run-manifests"
+    override val displayName = "Manifests"
+    override val defaultValue = ""
+    override val description = "Generate manifests during packaging."
+    override val advanced = true
+}
+
+object CrashReporterParameter : CheckboxParameter {
+    override val name = "build-cook-run-crash-reporter"
+    override val displayName = "CrashReporter"
+    override val defaultValue = ""
+    override val description = "Include CrashReporter support."
+    override val advanced = true
+}
+
+object DistributionParameter : CheckboxParameter {
+    override val name = "build-cook-run-distribution"
+    override val displayName = "Distribution"
+    override val defaultValue = ""
+    override val description = "Prepare the build for distribution."
+    override val advanced = true
+}
+
+object VerboseLoggingParameter : CheckboxParameter {
+    override val name = "build-cook-run-verbose"
+    override val displayName = "Verbose"
+    override val defaultValue = ""
+    override val description = "Enable verbose logging for BuildCookRun."
+    override val advanced = true
+}
+
+object LogWindowParameter : CheckboxParameter {
+    override val name = "build-cook-run-log-window"
+    override val displayName = "Log"
+    override val defaultValue = ""
+    override val description = "Open the Unreal log window while the command runs."
+    override val advanced = true
+}
+
+object NoXGEParameter : CheckboxParameter {
+    override val name = "build-cook-run-no-xge"
+    override val displayName = "NoXGE"
+    override val defaultValue = ""
+    override val description = "Disable XGE/Incredibuild distributed compilation."
+    override val advanced = true
+}
+
+object NoDebugInfoParameter : CheckboxParameter {
+    override val name = "build-cook-run-no-debug-info"
+    override val displayName = "NoDebugInfo"
+    override val defaultValue = ""
+    override val description = "Skip generating debug symbols for packaged builds."
+    override val advanced = true
+}
+
+object SkipEncryptionParameter : CheckboxParameter {
+    override val name = "build-cook-run-skip-encryption"
+    override val displayName = "SkipEncryption"
+    override val defaultValue = ""
+    override val description = "Disable encryption for pak/IoStore output."
+    override val advanced = true
+}
+
+data class BuildCookRunAdditionalOptions(
+    val installedBuild: Boolean = false,
+    val compile: Boolean = false,
+    val useIoStore: Boolean = false,
+    val noCompileUAT: Boolean = false,
+    val manifests: Boolean = false,
+    val crashReporter: Boolean = false,
+    val distribution: Boolean = false,
+    val verboseLogging: Boolean = false,
+    val logWindow: Boolean = false,
+    val noXGE: Boolean = false,
+    val noDebugInfo: Boolean = false,
+    val skipEncryption: Boolean = false,
+) {
+    companion object {
+        fun from(runnerParameters: Map<String, String>) =
+            BuildCookRunAdditionalOptions(
+                runnerParameters[InstalledBuildParameter.name].toBoolean(),
+                runnerParameters[CompileParameter.name].toBoolean(),
+                runnerParameters[UseIoStoreParameter.name].toBoolean(),
+                runnerParameters[NoCompileUATParameter.name].toBoolean(),
+                runnerParameters[ManifestsParameter.name].toBoolean(),
+                runnerParameters[CrashReporterParameter.name].toBoolean(),
+                runnerParameters[DistributionParameter.name].toBoolean(),
+                runnerParameters[VerboseLoggingParameter.name].toBoolean(),
+                runnerParameters[LogWindowParameter.name].toBoolean(),
+                runnerParameters[NoXGEParameter.name].toBoolean(),
+                runnerParameters[NoDebugInfoParameter.name].toBoolean(),
+                runnerParameters[SkipEncryptionParameter.name].toBoolean(),
+            )
+    }
+
+    val arguments: List<String> =
+        buildList {
+            if (installedBuild) add("-installed")
+            if (compile) add("-compile")
+            if (useIoStore) add("-iostore")
+            if (noCompileUAT) add("-nocompileuat")
+            if (manifests) add("-manifests")
+            if (crashReporter) add("-CrashReporter")
+            if (distribution) add("-distribution")
+            if (verboseLogging) add("-verbose")
+            if (logWindow) add("-log")
+            if (noXGE) add("-noxge")
+            if (noDebugInfo) add("-nodebuginfo")
+            if (skipEncryption) add("-skipencryption")
+        }
+}
+
+object GenerateChunksParameter : CheckboxParameter {
+    override val name = "build-cook-run-generate-chunks"
+    override val displayName = "Generate chunks"
+    override val defaultValue = ""
+    override val description = "Generate chunk manifests during cooking."
+    override val advanced = true
+}
+
+object IterativeCookingParameter : CheckboxParameter {
+    override val name = "build-cook-run-iterative-cooking"
+    override val displayName = "Iterative cooking"
+    override val defaultValue = ""
+    override val description = "Use iterative cooking to only process changed assets."
+    override val advanced = true
+}
+
+object CookAllParameter : CheckboxParameter {
+    override val name = "build-cook-run-cook-all"
+    override val displayName = "Cook all"
+    override val defaultValue = ""
+    override val description = "Cook all available content for the project."
+    override val advanced = true
+}
+
+object CookMapsOnlyParameter : CheckboxParameter {
+    override val name = "build-cook-run-cook-maps-only"
+    override val displayName = "Cook maps only"
+    override val defaultValue = ""
+    override val description = "When cooking all content, restrict cook output to maps and dependencies."
+    override val advanced = true
+}
+
+object CookPartialGCParameter : CheckboxParameter {
+    override val name = "build-cook-run-cook-partial-gc"
+    override val displayName = "Cook partial GC"
+    override val defaultValue = ""
+    override val description = "Allow partial garbage collection while cooking to reduce memory pressure."
+    override val advanced = true
+}
+
+object FastCookParameter : CheckboxParameter {
+    override val name = "build-cook-run-fast-cook"
+    override val displayName = "FastCook"
+    override val defaultValue = ""
+    override val description = "Enable FastCook mode when supported by the target platform."
+    override val advanced = true
+}
+
+object IgnoreCookErrorsParameter : CheckboxParameter {
+    override val name = "build-cook-run-ignore-cook-errors"
+    override val displayName = "IgnoreCookErrors"
+    override val defaultValue = ""
+    override val description = "Continue packaging even if cook reports errors."
+    override val advanced = true
+}
+
+object SkipCookingEditorContentParameter : CheckboxParameter {
+    override val name = "build-cook-run-skip-editor-content"
+    override val displayName = "Skip editor content"
+    override val defaultValue = ""
+    override val description = "Skip cooking editor-only content."
+    override val advanced = true
+}
+
+object ExcludeEditorContentParameter : CheckboxParameter {
+    override val name = "build-cook-run-exclude-editor-content"
+    override val displayName = "Exclude editor content"
+    override val defaultValue = ""
+    override val description = "Exclude editor-only content from the cooked output."
+    override val advanced = true
+}
+
+object AdditionalCookerOptionsParameter : com.jetbrains.teamcity.plugins.unrealengine.common.parameters.TextInputParameter {
+    override val name = "build-cook-run-additional-cooker-options"
+    override val displayName = "Additional cooker options"
+    override val defaultValue = ""
+    override val description = "Additional options passed to `-AdditionalCookerOptions`."
+    override val required = false
+    override val supportsVcsNavigation = false
+    override val expandable = true
+    override val advanced = true
+
+    fun from(runnerParameters: Map<String, String>) =
+        runnerParameters[name]
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+
+    fun toArgument(value: String): String {
+        val normalized = value.trim().trim('"')
+        val escaped = StringUtil.escapeQuotes(normalized)
+        return "-AdditionalCookerOptions=\"$escaped\""
+    }
+}
+

--- a/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/BuildCookRunCommand.kt
+++ b/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/BuildCookRunCommand.kt
@@ -18,6 +18,7 @@ data class BuildCookRunCommand(
     val cookOptions: CookOptions? = null,
     val stageOptions: StageOptions? = null,
     val archiveOptions: ArchiveOptions? = null,
+    val options: BuildCookRunAdditionalOptions = BuildCookRunAdditionalOptions(),
     val extraArguments: List<String> = emptyList(),
 ) : UnrealCommand {
     companion object {
@@ -30,6 +31,7 @@ data class BuildCookRunCommand(
                 val cookOptions = CookStageSwitchParameter.parseCookOptions(runnerParameters)
                 val stageOptions = StageStageSwitchParameter.parseStageOptions(runnerParameters)
                 val archiveOptions = ArchiveSwitchParameter.parseArchiveOptions(runnerParameters)
+                val options = BuildCookRunAdditionalOptions.from(runnerParameters)
 
                 val additionalOptions =
                     buildList {
@@ -46,6 +48,7 @@ data class BuildCookRunCommand(
                     cookOptions,
                     stageOptions,
                     archiveOptions,
+                    options,
                     additionalOptions,
                 )
             }
@@ -68,6 +71,7 @@ data class BuildCookRunCommand(
             cookOptions?.let { addAll(cookOptions.arguments) } ?: add("-skipcook")
             stageOptions?.let { addAll(stageOptions.toArguments()) } ?: add("-skipstage")
             archiveOptions?.let { addAll(archiveOptions.toArguments()) }
+            addAll(options.arguments)
 
             addAll(extraArguments)
         }

--- a/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/CookOptions.kt
+++ b/common/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/common/buildcookrun/CookOptions.kt
@@ -14,6 +14,16 @@ data class CookOptions(
     val mapsToCook: List<CookMap>? = null,
     val cookCultures: List<CookCulture>? = null,
     val unversionedContent: Boolean = false,
+    val generateChunks: Boolean = false,
+    val iterativeCooking: Boolean = false,
+    val cookAll: Boolean = false,
+    val cookMapsOnly: Boolean = false,
+    val cookPartialGC: Boolean = false,
+    val fastCook: Boolean = false,
+    val ignoreCookErrors: Boolean = false,
+    val skipCookingEditorContent: Boolean = false,
+    val excludeEditorContent: Boolean = false,
+    val additionalCookerOptions: String? = null,
 ) {
     companion object {
         fun from(runnerParameters: Map<String, String>) =
@@ -21,6 +31,16 @@ data class CookOptions(
                 MapsToCookParameter.from(runnerParameters),
                 CookCulturesParameter.from(runnerParameters),
                 UnversionedCookedContentParameter.from(runnerParameters),
+                runnerParameters[GenerateChunksParameter.name].toBoolean(),
+                runnerParameters[IterativeCookingParameter.name].toBoolean(),
+                runnerParameters[CookAllParameter.name].toBoolean(),
+                runnerParameters[CookMapsOnlyParameter.name].toBoolean(),
+                runnerParameters[CookPartialGCParameter.name].toBoolean(),
+                runnerParameters[FastCookParameter.name].toBoolean(),
+                runnerParameters[IgnoreCookErrorsParameter.name].toBoolean(),
+                runnerParameters[SkipCookingEditorContentParameter.name].toBoolean(),
+                runnerParameters[ExcludeEditorContentParameter.name].toBoolean(),
+                AdditionalCookerOptionsParameter.from(runnerParameters),
             )
     }
 
@@ -38,6 +58,46 @@ data class CookOptions(
 
             if (unversionedContent) {
                 add("-unversionedcookedcontent")
+            }
+
+            if (generateChunks) {
+                add("-generatechunks")
+            }
+
+            if (iterativeCooking) {
+                add("-iterativecooking")
+            }
+
+            if (cookAll) {
+                add("-cookall")
+            }
+
+            if (cookMapsOnly) {
+                add("-cookmapsonly")
+            }
+
+            if (cookPartialGC) {
+                add("-CookPartialGC")
+            }
+
+            if (fastCook) {
+                add("-FastCook")
+            }
+
+            if (ignoreCookErrors) {
+                add("-IgnoreCookErrors")
+            }
+
+            if (skipCookingEditorContent) {
+                add("-SkipCookingEditorContent")
+            }
+
+            if (excludeEditorContent) {
+                add("-ExcludeEditorContent")
+            }
+
+            additionalCookerOptions?.let {
+                add(AdditionalCookerOptionsParameter.toArgument(it))
             }
         }
 }

--- a/common/src/test/kotlin/BuildCookRunExecCommandTests.kt
+++ b/common/src/test/kotlin/BuildCookRunExecCommandTests.kt
@@ -6,8 +6,33 @@ import com.jetbrains.teamcity.plugins.unrealengine.common.UnrealTargetConfigurat
 import com.jetbrains.teamcity.plugins.unrealengine.common.UnrealTargetPlatform
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildConfiguration
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildConfigurationParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildCookRunAdditionalOptions
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildCookRunCommand
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildCookRunProjectPathParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.AdditionalCookerOptionsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CompileParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookOptions
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookAllParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookMapsOnlyParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookPartialGCParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookStageSwitchParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CrashReporterParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.DistributionParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ExcludeEditorContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.FastCookParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.GenerateChunksParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IgnoreCookErrorsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.InstalledBuildParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IterativeCookingParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.LogWindowParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ManifestsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoDebugInfoParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoCompileUATParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoXGEParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.SkipCookingEditorContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.SkipEncryptionParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UseIoStoreParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.VerboseLoggingParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnrealTargetConfigurationsParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnrealTargetPlatformsParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.parameters.AdditionalArgumentsParameter
@@ -165,6 +190,106 @@ class BuildCookRunExecCommandTests {
                         "-servertargetplatform=Linux+LinuxArm64",
                         "-skipcook",
                         "-skipstage",
+                    ),
+            ),
+            HappyPathTestCase(
+                runnerParameters =
+                    mapOf(
+                        BuildCookRunProjectPathParameter.name to "some-path",
+                        BuildConfigurationParameter.name to "StandaloneGame",
+                        UnrealTargetConfigurationsParameter.Standalone.name to "Shipping",
+                        UnrealTargetPlatformsParameter.Standalone.name to "Win64",
+                        CookStageSwitchParameter.name to true.toString(),
+                        GenerateChunksParameter.name to true.toString(),
+                        IterativeCookingParameter.name to true.toString(),
+                        CookAllParameter.name to true.toString(),
+                        CookMapsOnlyParameter.name to true.toString(),
+                        CookPartialGCParameter.name to true.toString(),
+                        FastCookParameter.name to true.toString(),
+                        IgnoreCookErrorsParameter.name to true.toString(),
+                        SkipCookingEditorContentParameter.name to true.toString(),
+                        ExcludeEditorContentParameter.name to true.toString(),
+                        AdditionalCookerOptionsParameter.name to "-cookincremental -cookprocesscount=1",
+                        CompileParameter.name to true.toString(),
+                        InstalledBuildParameter.name to true.toString(),
+                        UseIoStoreParameter.name to true.toString(),
+                        NoCompileUATParameter.name to true.toString(),
+                        ManifestsParameter.name to true.toString(),
+                        CrashReporterParameter.name to true.toString(),
+                        DistributionParameter.name to true.toString(),
+                        VerboseLoggingParameter.name to true.toString(),
+                        LogWindowParameter.name to true.toString(),
+                        NoXGEParameter.name to true.toString(),
+                        NoDebugInfoParameter.name to true.toString(),
+                        SkipEncryptionParameter.name to true.toString(),
+                    ),
+                parsedCommand =
+                    BuildCookRunCommand(
+                        UnrealProjectPath("some-path"),
+                        BuildConfiguration.Standalone(
+                            nonEmptyListOf(UnrealTargetConfiguration.Shipping),
+                            nonEmptyListOf(UnrealTargetPlatform.Win64),
+                        ),
+                        cookOptions =
+                            CookOptions(
+                                generateChunks = true,
+                                iterativeCooking = true,
+                                cookAll = true,
+                                cookMapsOnly = true,
+                                cookPartialGC = true,
+                                fastCook = true,
+                                ignoreCookErrors = true,
+                                skipCookingEditorContent = true,
+                                excludeEditorContent = true,
+                                additionalCookerOptions = "-cookincremental -cookprocesscount=1",
+                            ),
+                        options =
+                            BuildCookRunAdditionalOptions(
+                                installedBuild = true,
+                                compile = true,
+                                useIoStore = true,
+                                noCompileUAT = true,
+                                manifests = true,
+                                crashReporter = true,
+                                distribution = true,
+                                verboseLogging = true,
+                                logWindow = true,
+                                noXGE = true,
+                                noDebugInfo = true,
+                                skipEncryption = true,
+                            ),
+                    ),
+                expectedArguments =
+                    listOf(
+                        "BuildCookRun",
+                        "-project=${context.workingDirectory}/some-path",
+                        "-build",
+                        "-configuration=Shipping",
+                        "-targetplatform=Win64",
+                        "-cook",
+                        "-generatechunks",
+                        "-iterativecooking",
+                        "-cookall",
+                        "-cookmapsonly",
+                        "-CookPartialGC",
+                        "-FastCook",
+                        "-IgnoreCookErrors",
+                        "-SkipCookingEditorContent",
+                        "-ExcludeEditorContent",
+                        "-AdditionalCookerOptions=\"-cookincremental -cookprocesscount=1\"",
+                        "-skipstage",
+                        "-installed",
+                        "-compile",
+                        "-iostore",
+                        "-nocompileuat",
+                        "-manifests",
+                        "-CrashReporter",
+                        "-distribution",
+                        "-verbose",
+                        "-log",
+                        "-noxge",
+                        "-nodebuginfo",
+                        "-skipencryption",
                     ),
             ),
         )

--- a/common/src/test/kotlin/CookOptionsTests.kt
+++ b/common/src/test/kotlin/CookOptionsTests.kt
@@ -1,9 +1,19 @@
 
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookCulture
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.AdditionalCookerOptionsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookAllParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookCulturesParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookMap
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookMapsOnlyParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookOptions
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookPartialGCParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ExcludeEditorContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.FastCookParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.GenerateChunksParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IgnoreCookErrorsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IterativeCookingParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.MapsToCookParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.SkipCookingEditorContentParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnversionedCookedContentParameter
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldNotContainAnyOf
@@ -27,6 +37,17 @@ class CookOptionsTests {
                         MapsToCookParameter.name to "Map1+Map2+Map3",
                         CookCulturesParameter.name to "Culture1+Culture2",
                         UnversionedCookedContentParameter.name to true.toString(),
+                        GenerateChunksParameter.name to true.toString(),
+                        IterativeCookingParameter.name to true.toString(),
+                        CookAllParameter.name to true.toString(),
+                        CookMapsOnlyParameter.name to true.toString(),
+                        CookPartialGCParameter.name to true.toString(),
+                        FastCookParameter.name to true.toString(),
+                        IgnoreCookErrorsParameter.name to true.toString(),
+                        SkipCookingEditorContentParameter.name to true.toString(),
+                        ExcludeEditorContentParameter.name to true.toString(),
+                        AdditionalCookerOptionsParameter.name to
+                            "-cookincremental -tracefile=%teamcity.build.checkoutDir%/Saved/CookInsights.utrace",
                     ),
                 expectedOptions =
                     CookOptions(
@@ -42,6 +63,17 @@ class CookOptionsTests {
                                 CookCulture("Culture2"),
                             ),
                         unversionedContent = true,
+                        generateChunks = true,
+                        iterativeCooking = true,
+                        cookAll = true,
+                        cookMapsOnly = true,
+                        cookPartialGC = true,
+                        fastCook = true,
+                        ignoreCookErrors = true,
+                        skipCookingEditorContent = true,
+                        excludeEditorContent = true,
+                        additionalCookerOptions =
+                            "-cookincremental -tracefile=%teamcity.build.checkoutDir%/Saved/CookInsights.utrace",
                     ),
                 shouldContainItems =
                     listOf(
@@ -49,6 +81,16 @@ class CookOptionsTests {
                         "-map=Map1+Map2+Map3",
                         "-cookcultures=Culture1+Culture2",
                         "-unversionedcookedcontent",
+                        "-generatechunks",
+                        "-iterativecooking",
+                        "-cookall",
+                        "-cookmapsonly",
+                        "-CookPartialGC",
+                        "-FastCook",
+                        "-IgnoreCookErrors",
+                        "-SkipCookingEditorContent",
+                        "-ExcludeEditorContent",
+                        "-AdditionalCookerOptions=\"-cookincremental -tracefile=%teamcity.build.checkoutDir%/Saved/CookInsights.utrace\"",
                     ),
                 shouldNotContainItems = emptyList(),
             ),
@@ -56,7 +98,22 @@ class CookOptionsTests {
                 runnerParameters = mapOf(),
                 expectedOptions = CookOptions(),
                 shouldContainItems = listOf("-cook"),
-                shouldNotContainItems = listOf("-map", "-cookcultures", "-unversionedcookedcontent"),
+                shouldNotContainItems =
+                    listOf(
+                        "-map",
+                        "-cookcultures",
+                        "-unversionedcookedcontent",
+                        "-generatechunks",
+                        "-iterativecooking",
+                        "-cookall",
+                        "-cookmapsonly",
+                        "-CookPartialGC",
+                        "-FastCook",
+                        "-IgnoreCookErrors",
+                        "-SkipCookingEditorContent",
+                        "-ExcludeEditorContent",
+                        "-AdditionalCookerOptions",
+                    ),
             ),
         )
 

--- a/kotlin-dsl/unreal-engine-runner.xml
+++ b/kotlin-dsl/unreal-engine-runner.xml
@@ -137,6 +137,66 @@
                                 The default value is "true".
                             </description>
                         </param>
+
+                        <param name="build-cook-run-generate-chunks" dslName="generateChunks" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Generate chunk manifests during cooking.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-iterative-cooking" dslName="iterativeCooking" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Use iterative cooking to process only changed assets.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-cook-all" dslName="cookAll" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Cook all available project content.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-cook-maps-only" dslName="cookMapsOnly" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                With cook-all, limit output to maps and their dependencies.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-cook-partial-gc" dslName="cookPartialGC" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Allow partial garbage collection while cooking.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-fast-cook" dslName="fastCook" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Enable FastCook mode when supported by the target platform.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-ignore-cook-errors" dslName="ignoreCookErrors" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Continue packaging even if cook reports errors.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-skip-editor-content" dslName="skipCookingEditorContent" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Skip cooking editor-only content.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-exclude-editor-content" dslName="excludeEditorContent" type="boolean" trueValue="true" falseValue="">
+                            <description>
+                                Exclude editor-only content from the cooked output.
+                            </description>
+                        </param>
+
+                        <param name="build-cook-run-additional-cooker-options" dslName="additionalCookerOptions" type="string">
+                            <description>
+                                Additional options passed to `-AdditionalCookerOptions`.
+                            </description>
+                        </param>
                     </option>
                     <option name="skipCook" value="false"/>
                 </param>
@@ -161,6 +221,12 @@
                     	Allows you to put all assets into a single ".pak" file instead of copying individual files.
                         This approach reduces the number of transferred files that benefits projects with a large amount of asset files.
                         The default value is "true".
+                    </description>
+                </param>
+
+                <param name="build-cook-run-iostore" dslName="iostore" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Store cooked content in IoStore containers.
                     </description>
                 </param>
 
@@ -196,6 +262,72 @@
                         </param>
                     </option>
                     <option name="skipArchive" value="false"/>
+                </param>
+
+                <param name="build-cook-run-compile" dslName="compile" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Compile the selected targets before running BuildCookRun.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-installed" dslName="installedBuild" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Use an installed engine build.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-no-compile-uat" dslName="noCompileUAT" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Skip compiling Unreal Automation Tool.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-manifests" dslName="manifests" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Generate manifests during packaging.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-crash-reporter" dslName="crashReporter" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Include CrashReporter support.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-distribution" dslName="distribution" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Prepare the build for distribution.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-verbose" dslName="verbose" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Enable verbose logging for BuildCookRun.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-log-window" dslName="logWindow" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Open the Unreal log window while the command runs.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-no-xge" dslName="noXGE" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Disable XGE/Incredibuild distributed compilation.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-no-debug-info" dslName="noDebugInfo" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Skip generating debug symbols for packaged builds.
+                    </description>
+                </param>
+
+                <param name="build-cook-run-skip-encryption" dslName="skipEncryption" type="boolean" trueValue="true" falseValue="">
+                    <description>
+                        Disable encryption for pak/IoStore output.
+                    </description>
                 </param>
 
             </option>
@@ -451,14 +583,29 @@
                             maps = "FooMap+BarMap"
                             cultures = "FooCulture+BarCulture"
                             unversionedContent = true
+                            generateChunks = true
+                            iterativeCooking = true
+                            cookAll = true
+                            cookMapsOnly = true
+                            cookPartialGC = true
+                            fastCook = true
+                            ignoreCookErrors = false
+                            skipCookingEditorContent = true
+                            additionalCookerOptions = "-cookincremental -cookprocesscount=1"
                         }
                         stage = stageConfiguration {
                             directory = "./staged"
                         }
                         packageProject = true
                         pak = true
+                        iostore = true
                         compressed = true
                         prerequisites = true
+                        manifests = true
+                        installedBuild = true
+                        noXGE = true
+                        noDebugInfo = true
+                        skipEncryption = false
                         archive = archiveConfiguration {
                             directory = "./archived"
                         }

--- a/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/UnrealEngineRunnerParametersProvider.kt
+++ b/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/UnrealEngineRunnerParametersProvider.kt
@@ -8,14 +8,37 @@ import com.jetbrains.teamcity.plugins.unrealengine.common.automation.tests.NullR
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ArchiveSwitchParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildConfigurationParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.BuildCookRunProjectPathParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnrealBuildTargetParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CrashReporterParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CompileParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CompressedContentParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookStageSwitchParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookAllParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookMapsOnlyParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookPartialGCParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.AdditionalCookerOptionsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.DistributionParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ExcludeEditorContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.FastCookParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.GenerateChunksParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IgnoreCookErrorsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.InstalledBuildParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IterativeCookingParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.LogWindowParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ManifestsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoDebugInfoParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoCompileUATParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoXGEParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.PackageStageSwitchParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.PrerequisitesParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.SkipCookingEditorContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.SkipEncryptionParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.StageStageSwitchParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnrealTargetConfigurationsParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnversionedCookedContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UseIoStoreParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UsePakParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.VerboseLoggingParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildgraph.BuildGraphOptionsParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildgraph.BuildGraphScriptPathParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildgraph.BuildGraphTargetNodeParameter
@@ -47,14 +70,37 @@ class UnrealEngineRunnerParametersProvider {
                 UnrealTargetConfigurationsParameter.Standalone,
                 UnrealTargetConfigurationsParameter.Client,
                 UnrealTargetConfigurationsParameter.Server,
+                UnrealBuildTargetParameter,
                 CookStageSwitchParameter,
                 UnversionedCookedContentParameter,
+                GenerateChunksParameter,
+                IterativeCookingParameter,
+                CookAllParameter,
+                CookMapsOnlyParameter,
+                CookPartialGCParameter,
+                FastCookParameter,
+                IgnoreCookErrorsParameter,
+                SkipCookingEditorContentParameter,
+                ExcludeEditorContentParameter,
+                AdditionalCookerOptionsParameter,
                 StageStageSwitchParameter,
                 UsePakParameter,
+                UseIoStoreParameter,
                 CompressedContentParameter,
                 PrerequisitesParameter,
                 PackageStageSwitchParameter,
                 ArchiveSwitchParameter,
+                CompileParameter,
+                InstalledBuildParameter,
+                NoCompileUATParameter,
+                ManifestsParameter,
+                CrashReporterParameter,
+                DistributionParameter,
+                VerboseLoggingParameter,
+                LogWindowParameter,
+                NoXGEParameter,
+                NoDebugInfoParameter,
+                SkipEncryptionParameter,
                 BuildCookRunProjectPathParameter,
             )
 

--- a/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/ui/ComponentParametersFormatter.kt
+++ b/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/ui/ComponentParametersFormatter.kt
@@ -8,11 +8,11 @@ object ComponentParametersFormatter {
         properties: Map<String, String>,
     ) = flags
         .filter {
-            properties.containsKey(it.name)
+            properties[it.name].toBoolean()
         }.joinToString(separator = ",") { it.displayName }
 
     fun formatFlag(
         flag: CheckboxParameter,
         properties: Map<String, String>,
-    ): String = if (properties.containsKey(flag.name)) "Yes" else "No"
+    ): String = if (properties[flag.name].toBoolean()) "Yes" else "No"
 }

--- a/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/ui/CookComponent.kt
+++ b/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/ui/CookComponent.kt
@@ -1,20 +1,49 @@
 package com.jetbrains.teamcity.plugins.unrealengine.server.runner.ui
 
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookCulturesParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookAllParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookMapsOnlyParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookPartialGCParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CookStageSwitchParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ExcludeEditorContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.FastCookParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.GenerateChunksParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IgnoreCookErrorsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.IterativeCookingParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.MapsToCookParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.SkipCookingEditorContentParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UnversionedCookedContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.AdditionalCookerOptionsParameter
 
 class CookComponent {
     val cook = CookStageSwitchParameter
     val maps = MapsToCookParameter
     val cultures = CookCulturesParameter
     val unversionedContent = UnversionedCookedContentParameter
+    val generateChunks = GenerateChunksParameter
+    val iterativeCooking = IterativeCookingParameter
+    val cookAll = CookAllParameter
+    val cookMapsOnly = CookMapsOnlyParameter
+    val cookPartialGC = CookPartialGCParameter
+    val fastCook = FastCookParameter
+    val ignoreCookErrors = IgnoreCookErrorsParameter
+    val skipEditorContent = SkipCookingEditorContentParameter
+    val excludeEditorContent = ExcludeEditorContentParameter
+    val additionalCookerOptions = AdditionalCookerOptionsParameter
 
     fun formatFlags(properties: Map<String, String>) =
         ComponentParametersFormatter.formatFlags(
             sequenceOf(
                 unversionedContent,
+                generateChunks,
+                iterativeCooking,
+                cookAll,
+                cookMapsOnly,
+                cookPartialGC,
+                fastCook,
+                ignoreCookErrors,
+                skipEditorContent,
+                excludeEditorContent,
             ),
             properties,
         )

--- a/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/ui/RunComponent.kt
+++ b/server/src/main/kotlin/com/jetbrains/teamcity/plugins/unrealengine/server/runner/ui/RunComponent.kt
@@ -2,12 +2,24 @@ package com.jetbrains.teamcity.plugins.unrealengine.server.runner.ui
 
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ArchiveDirectoryParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ArchiveSwitchParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CrashReporterParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CompileParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.CompressedContentParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.DistributionParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.InstalledBuildParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.LogWindowParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.ManifestsParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoDebugInfoParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoCompileUATParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.NoXGEParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.PackageStageSwitchParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.PrerequisitesParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.SkipEncryptionParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.StageStageSwitchParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.StagingDirectoryParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UseIoStoreParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.UsePakParameter
+import com.jetbrains.teamcity.plugins.unrealengine.common.buildcookrun.VerboseLoggingParameter
 import com.jetbrains.teamcity.plugins.unrealengine.common.parameters.CheckboxParameter
 
 class RunComponent {
@@ -22,13 +34,38 @@ class RunComponent {
     val archiveBuild = ArchiveSwitchParameter
     val archiveDirectory = ArchiveDirectoryParameter
 
+    val compile = CompileParameter
+    val installedBuild = InstalledBuildParameter
+    val useIoStore = UseIoStoreParameter
+    val noCompileUAT = NoCompileUATParameter
+    val manifests = ManifestsParameter
+    val crashReporter = CrashReporterParameter
+    val distribution = DistributionParameter
+    val verboseLogging = VerboseLoggingParameter
+    val logWindow = LogWindowParameter
+    val noXGE = NoXGEParameter
+    val noDebugInfo = NoDebugInfoParameter
+    val skipEncryption = SkipEncryptionParameter
+
     fun formatFlags(properties: Map<String, String>) =
         ComponentParametersFormatter
             .formatFlags(
                 sequenceOf(
+                    compile,
+                    installedBuild,
                     usePak,
+                    useIoStore,
                     compressedContent,
                     prerequisites,
+                    noCompileUAT,
+                    manifests,
+                    crashReporter,
+                    distribution,
+                    verboseLogging,
+                    logWindow,
+                    noXGE,
+                    noDebugInfo,
+                    skipEncryption,
                 ),
                 properties,
             )

--- a/server/src/main/resources/buildServerResources/commands/editCookSettings.jspf
+++ b/server/src/main/resources/buildServerResources/commands/editCookSettings.jspf
@@ -20,6 +20,36 @@
 <c:set var="parameter" value="${cookComponent.unversionedContent}"/>
 <%@ include file="../common/checkbox.jspf"%>
 
+<c:set var="parameter" value="${cookComponent.generateChunks}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.iterativeCooking}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.cookAll}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.cookMapsOnly}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.cookPartialGC}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.fastCook}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.ignoreCookErrors}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.skipEditorContent}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.excludeEditorContent}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${cookComponent.additionalCookerOptions}"/>
+<%@ include file="../common/textField.jspf"%>
+
 <c:set var="cssClass" value=""/>
 <c:set var="noBorder" value=""/>
 

--- a/server/src/main/resources/buildServerResources/commands/editRunSettings.jspf
+++ b/server/src/main/resources/buildServerResources/commands/editRunSettings.jspf
@@ -11,10 +11,46 @@
 <c:set var="parameter" value="${runComponent.usePak}"/>
 <%@ include file="../common/checkbox.jspf"%>
 
+<c:set var="parameter" value="${runComponent.useIoStore}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
 <c:set var="parameter" value="${runComponent.compressedContent}"/>
 <%@ include file="../common/checkbox.jspf"%>
 
 <c:set var="parameter" value="${runComponent.prerequisites}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.compile}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.installedBuild}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.noCompileUAT}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.manifests}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.crashReporter}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.distribution}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.verboseLogging}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.logWindow}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.noXGE}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.noDebugInfo}"/>
+<%@ include file="../common/checkbox.jspf"%>
+
+<c:set var="parameter" value="${runComponent.skipEncryption}"/>
 <%@ include file="../common/checkbox.jspf"%>
 
 <c:set var="noBorder" value=""/>

--- a/server/src/main/resources/buildServerResources/commands/viewCookSettings.jspf
+++ b/server/src/main/resources/buildServerResources/commands/viewCookSettings.jspf
@@ -27,6 +27,12 @@
                 Cook flags: <strong>${cookFlags}</strong>
             </div>
         </c:if>
+
+        <c:if test="${not empty propertiesBean.properties[cookComponent.additionalCookerOptions.name]}">
+            <div class="parameter">
+                ${cookComponent.additionalCookerOptions.displayName}: <props:displayValue name="${cookComponent.additionalCookerOptions.name}"/>
+            </div>
+        </c:if>
     </c:when>
     <c:otherwise>
         <div class="parameter">

--- a/server/src/main/resources/buildServerResources/commands/viewRunSettings.jspf
+++ b/server/src/main/resources/buildServerResources/commands/viewRunSettings.jspf
@@ -16,10 +16,10 @@
     </div>
 </c:if>
 
-<c:set var="runFalgs" value="${runComponent.formatFlags(propertiesBean.properties)}"/>
-<c:if test="${not empty runFalgs}">
+<c:set var="runFlags" value="${runComponent.formatFlags(propertiesBean.properties)}"/>
+<c:if test="${not empty runFlags}">
     <div class="parameter">
-        Run flags: <strong>${runFalgs}</strong>
+        Run flags: <strong>${runFlags}</strong>
     </div>
 </c:if>
 


### PR DESCRIPTION
## What this changes
- adds native BuildCookRun parameters for common flags currently passed via raw additionalArguments
- adds first-class support for -AdditionalCookerOptions in cook settings
- adds native cook-side flags: -generatechunks, -iterativecooking, -cookall, -cookmapsonly, -CookPartialGC, -FastCook, -IgnoreCookErrors, -SkipCookingEditorContent, -ExcludeEditorContent
- adds native run/build flags: -installed, -compile, -iostore, -nocompileuat, -manifests, -CrashReporter, -distribution, -verbose, -log, -noxge, -nodebuginfo, -skipencryption
- keeps compatibility with existing additionalArguments usage
- polishes docs wording to consistently use Kotlin DSL option names in usage guidance

## Source reference
- validated parameter candidates against UE 5.5.4 source in D:\custom_ue (AutomationTool BuildCookRun/ProjectParams)

## Where updated
- common command model + parsing + argument generation
- server parameter defaults/provider and UI form/view components
- Kotlin DSL descriptor and examples
- usage docs and changelog
- regression tests for parsing and argument emission

## Validation
- ./gradlew.bat :common:test --tests BuildCookRunExecCommandTests --tests CookOptionsTests
- ./gradlew.bat :server:test -x :server:buildFront